### PR TITLE
Improvement of the ``rm`` command (#21)

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"testing"
 
@@ -188,4 +190,21 @@ func SameSlices(a, b []string) bool {
 	}
 
 	return true
+}
+
+// captureStdout returns the output of a function
+// not thread safe
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -178,6 +178,14 @@ func fbTestTempestcf(t *testing.T, tempestcfbup string) {
 // SameSlices checks equality between two slices of string
 // returns true if they are identiques
 func SameSlices(a, b []string) bool {
+	if a == nil && nil == b {
+		return true
+	}
+
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+
 	if len(a) != len(b) {
 		return false
 	}
@@ -195,6 +203,14 @@ func SameSlices(a, b []string) bool {
 // SameSlicesInt checks equality between two slices of int
 // returns true if they are identiques
 func SameSlicesInt(a, b []int) bool {
+	if a == nil && nil == b {
+		return true
+	}
+
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+
 	if len(a) != len(b) {
 		return false
 	}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -175,9 +175,26 @@ func fbTestTempestcf(t *testing.T, tempestcfbup string) {
 	Tempestcf = tempestcfbup
 }
 
-// SameSlices checks equality between two slices
+// SameSlices checks equality between two slices of string
 // returns true if they are identiques
 func SameSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	b = b[:len(a)]
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// SameSlicesInt checks equality between two slices of int
+// returns true if they are identiques
+func SameSlicesInt(a, b []int) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,8 +33,8 @@ import (
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Lists all the paths submitted to TEMPest.",
-	Long: `All the paths set for TEMPest.
+	Short: "Lists all the targets submitted to TEMPest.",
+	Long: `All the targets set for TEMPest.
 
 They follow this pattern:
 <IndexPath> <Path>
@@ -48,7 +48,7 @@ The IndexPath can then be used to select the path
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if errLi := printList(); errLi != nil {
-			fmt.Println(color.HiRedString("Could not list paths, sorry bra!", errLi))
+			fmt.Println(color.HiRedString("Could not list targets, sorry bra!", errLi))
 		}
 	},
 }
@@ -78,7 +78,7 @@ func printList() error {
 	if errSliced != nil {
 		// Just a small enhancement of the "no paths set yet" display
 		if errSliced.Error() == "empty" {
-			fmt.Println(color.HiMagentaString(":: No path set yet\n:: Suggestion - Run: \n\ttempest help add\nFor more information about adding paths!"))
+			fmt.Println(color.HiMagentaString(":: No pattargeth set yet\n:: Suggestion - Run: \n\ttempest help add\nFor more information about adding targets!"))
 			return nil
 		}
 		return errSliced
@@ -86,8 +86,8 @@ func printList() error {
 
 	// color.Red(fmt.Sprintf("%d", len(ctntSlice)))
 	if len(ctntSlice) >= 1 {
-		fmt.Println(color.HiYellowString("Current paths currently having \"fun\" with TEMPest:\n"))
-		fmt.Println(color.HiYellowString("Index\t| Path"))
+		fmt.Println(color.HiYellowString("Current targets currently having \"fun\" with TEMPest:\n"))
+		fmt.Println(color.HiYellowString("Index\t| Target"))
 		// fmt.Println(color.HiYellowString("--------------------------------------------------"))
 	}
 
@@ -97,7 +97,7 @@ func printList() error {
 		case i < len(aPath):
 			fmt.Println(color.HiYellowString(fmt.Sprintf("%d\t|", i)), aPath)
 		case i == 0:
-			fmt.Println(color.HiMagentaString("No path set yet\nSuggestion - Run: \n\ttempest help add\nFor more information about adding paths!"))
+			fmt.Println(color.HiMagentaString("No target set yet\nSuggestion - Run: \n\ttempest help add\nFor more information about adding targets!"))
 		}
 	}
 	return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -78,7 +78,7 @@ func printList() error {
 	if errSliced != nil {
 		// Just a small enhancement of the "no paths set yet" display
 		if errSliced.Error() == "empty" {
-			fmt.Println(color.HiMagentaString(":: No pattargeth set yet\n:: Suggestion - Run: \n\ttempest help add\nFor more information about adding targets!"))
+			fmt.Println(color.HiMagentaString(":: No target set yet\n:: Suggestion - Run: \n\ttempest help add\nFor more information about adding targets!"))
 			return nil
 		}
 		return errSliced

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"bytes"
-	"io"
 	"os"
 	"testing"
 )
@@ -68,7 +66,7 @@ func TestPrintList(t *testing.T) {
 	})
 
 	// Verify output
-	wantedOutput := ":: No path set yet\n:: Suggestion - Run: \n\ttempest help add\nFor more information about adding paths!\n"
+	wantedOutput := ":: No target set yet\n:: Suggestion - Run: \n\ttempest help add\nFor more information about adding targets!\n"
 	if wantedOutput != emptyOutput {
 		t.Log("[FAIL]:: printList() failed to process empty .tempestcf\n\t-> Expected:\n\t", wantedOutput, "\n\t-> Got:\n\t", emptyOutput)
 		t.Fail()
@@ -95,7 +93,7 @@ func TestPrintList(t *testing.T) {
 	})
 
 	// Verify output of printList()
-	wantedOutput = "Current paths currently having \"fun\" with TEMPest:\n\nIndex\t| Path\n0\t| " + conf.Gobin + "\n1\t| " + conf.Gopath + "\n"
+	wantedOutput = "Current targets currently having \"fun\" with TEMPest:\n\nIndex\t| Target\n0\t| " + conf.Gobin + "\n1\t| " + conf.Gopath + "\n"
 	if actualOutput != wantedOutput {
 		t.Log("[FAIL]:: The output of printList() was quite unexpected! Wow!\n\t-> ActualOutput:\n\t", actualOutput, "\n\t-> Wanted:\n\t", wantedOutput)
 		t.Fail()
@@ -103,21 +101,4 @@ func TestPrintList(t *testing.T) {
 
 	// Fallback
 	fbTestTempestcf(t, tempestcfbup)
-}
-
-// captureStdout returns the output of a function
-// not thread safe
-func captureStdout(f func()) string {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	f()
-
-	w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	return buf.String()
 }

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -211,7 +211,7 @@ func deleteAllStr(path string, targets []os.FileInfo, testMode bool) error {
 func deleteAllInt(index int, testMode bool) error {
 	allPaths, errPaths := getPaths()
 	if errPaths != nil {
-		color.Red("::Error while reading .tempestcf")
+		color.Red(":: Error while reading .tempestcf")
 		return errPaths
 	}
 	if index >= 0 && index < len(allPaths) {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -71,14 +72,18 @@ or
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		// color.Cyan("Sorry, rm is not fully implemented yet... Coming soon don't worry!")
-		if len(args) == 0 && rmInt == -1 && rmStr == "" {
-			rmStr = "this"
-		}
+		// if len(args) == 0 && rmInt == -1 && rmStr == "" {
+		// 	rmStr = "this"
+		// }
+
+		// handles rm's args
+		// slRmInt, slRmStr := processArgsRm(args)
+
 		slicePaths, errAllP := getPaths()
 		if errAllP != nil {
 			color.Red(errAllP.Error())
 		}
-		slicePaths = rmInSlice(rmInt, rmStr, slicePaths)
+		slicePaths = rmInSlice(rmInt, rmStr, slicePaths) // TODO change this to take slices rmInt & Str
 
 		if errWrite := writeTempestcf(slicePaths); errWrite != nil {
 			color.Red(errWrite.Error())
@@ -107,6 +112,40 @@ func init() {
 	rmCmd.Flags().StringVarP(&rmStr, "path", "p", "", "The path of a target for TEMPest")
 
 	rmCmd.Flags().BoolVarP(&rmOrigin, "origin", "o", false, "Removes the target from TEMPest, but also the original directories/files")
+}
+
+// processArgsRm takes the args as parameters and process them
+func processArgsRm(args []string) ([]int, []string) {
+	// TODO process stuff hunh?
+	slRmInt := make([]int, 0)
+	slRmStr := make([]string, 0)
+
+	// Slice into string
+	var strified string
+	for _, valStr := range args {
+		strified += valStr + " "
+	}
+
+	// regexes
+	regexSimpleInt := regexp.MustCompile(`([0-9]+\s|[0-9]+$)`)
+	switch {
+	case regexSimpleInt.FindString(strified) == strified:
+		// then that's it
+	}
+	//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> NOTE: WTFFFFFF!!?????
+	// for _, arg := range args {
+	// 	switch {
+	// 	case len(args) == 0 && rmInt[0] == -1 && rmStr[0] == "":
+	// 		slRmStr = append(slRmStr, "this")
+	// 		slRmInt = append(slRmInt, rmInt[0])
+	// 		return slRmInt, slRmStr
+	// 	case len(args) > 0 && rmInt[0] == -1:
+	// 		//todo
+	// 	}
+
+	// }
+
+	return slRmInt, slRmStr
 }
 
 // rmInSlice give it a slice with an index of path to remove.

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -33,14 +33,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// @DEPRECATED
-// rmInt is the index to remove from the TEMPest list
-// var rmInt int
-
-// @DEPRECATED
-// rmStr is the path to be removed from TEMpest
-// var rmStr string
-
 // rmOrigin defines whether the origin directory/file should be deleted too
 var rmOrigin bool
 
@@ -52,7 +44,7 @@ var rmCmd = &cobra.Command{
 The basic command does not delete the original directory or file.
 It's just telling to TEMPest to untrack the file/directory. For example:
 
-	tempest rm -p /tmp
+	tempest rm /tmp
 
 or
 Place yourself inside the directory and run:
@@ -63,15 +55,32 @@ If it is a directory tracked by TEMPest, it will be untracked, otherwise you wil
 
 It is also possible to use the index number resulting of the tempest list command:
 
-	tempest rm -i 1
+	tempest rm 1
 
 ` + color.RedString("/!\\ [WARNING] After removing a file, the index number might change!!") + `
 
+It is possible to remove many targets at the same time:
+	tempest rm 1 3 2 7
+or
+	tempest rm /tmp /temp
+
+To remove the current directory, for example, if we want to remove /tmp:
+	cd /tmp
+	tempest rm
+
+Using indexes for rm allows to use ranges which, for now can't be done using targets paths. 
+Examples:
+	tempest rm 1-3
+		-> This removes the targets matching the indexes 1 to 3 (1, 2 and 3)
+
+To remove all your targets from TEMPest:
+	tempest rm *
+
 In order to remove the original file/directory:
 
-	tempest rm -o 1
+	tempest rm 1 -o
 or
-	tempest rm --origin 1
+	tempest rm 1 --origin
 
 => Considering 1 is /tmp, this would remove /tmp from TEMPest AND from your device.
 
@@ -89,7 +98,6 @@ or
 		if errAllP != nil {
 			color.Red(errAllP.Error())
 		}
-		// slicePaths = rmInSlice(rmInt, rmStr, slicePaths) // @DEPRECATED
 		slRmInt, slRmStr := processArgsRm(args)
 		slicePaths = rmInSlice(slRmInt, slRmStr, slicePaths)
 

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -78,9 +78,9 @@ or
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		// color.Cyan("Sorry, rm is not fully implemented yet... Coming soon don't worry!")
-		// if len(args) == 0 && rmInt == -1 && rmStr == "" {
-		// 	rmStr = "this"
-		// }
+		if len(args) == 0 {
+			args = append(args, "this")
+		}
 
 		// handles rm's args
 		// slRmInt, slRmStr := processArgsRm(args)
@@ -142,8 +142,12 @@ func processArgsRm(args []string) ([]int, []string) {
 
 	for _, arg := range args { // for each arg in args
 		arg = strings.Trim(arg, " ")
+		// Wildcard: * (ALL)
+		if arg == "*" && len(args) == 1 {
+			slRmStr = append(slRmStr, arg)
+		}
 		// Empty arg
-		if arg == "" {
+		if arg == "this" {
 			if !IsStringInSlice("this", slRmStr) {
 				slRmStr = append(slRmStr, "this")
 			}
@@ -190,21 +194,6 @@ func processArgsRm(args []string) ([]int, []string) {
 
 	}
 
-	// // if RegexManyInt.FindString(strified) == strified {
-	// // 	// then that's it
-	// // }
-	// @DEPRECATED
-	// for _, arg := range args {
-	// 	switch {
-	// 	case len(args) == 0 && rmInt[0] == -1 && rmStr[0] == "":
-	// 		slRmStr = append(slRmStr, "this")
-	// 		slRmInt = append(slRmInt, rmInt[0])
-	// 		return slRmInt, slRmStr
-	// 	case len(args) > 0 && rmInt[0] == -1:
-	// 	}
-
-	// }
-
 	return slRmInt, slRmStr
 }
 
@@ -230,6 +219,10 @@ func rmInSlice(indexes []int, slRmStr []string, list []string) []string {
 				indexes = append(indexes, i)
 			}
 		}
+
+		if record == "*" {
+			return []string{}
+		}
 	}
 
 	// Slicing an element out of the slice.
@@ -237,7 +230,7 @@ func rmInSlice(indexes []int, slRmStr []string, list []string) []string {
 	// 	a = a[:1+copy(a[1:], a[2:])]
 	// listToRet := list[:index+copy(list[index:], list[index+1:])]
 
-	// if we have to, remove the directories/files
+	//* if we have to, remove the directories/files
 	if rmOrigin {
 		// need to find another way QQ
 		trashSlice := make([]string, 0)
@@ -250,17 +243,20 @@ func rmInSlice(indexes []int, slRmStr []string, list []string) []string {
 		}
 	}
 
-	//* Remove from slice
+	//* Remove from slice if has stuff to remove
 	listToRet := make([]string, 0)
-	for _, index := range indexes {
-		// Is this right? :(
-		listToRet = append(listToRet, list[:index]...)
-		listToRet = append(listToRet, list[index+1:]...)
+	if len(indexes) > 0 {
+		for i, item := range list {
+			if !IsIntInSlice(i, indexes) {
+				listToRet = append(listToRet, item)
+			}
+		}
 	}
 
 	// DEBUG
 	// color.HiYellow(fmt.Sprintf("%v", list))
 
+	// just for linter ...
 	return listToRet
 }
 

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -154,3 +154,36 @@ func TestWriteTempestcf(t *testing.T) {
 	}
 	Tempestcf = tempestcfbup
 }
+
+// TestProcessArgsRm is the test for processArgsRm.
+// It verifies that it returns the right slices
+func TestProcessArgsRm(t *testing.T) {
+	// parameter variables
+	s1 := []string{"0-1"}
+	s2 := []string{"0-2", "5-7"}
+	s3 := []string{""}
+
+	emptySliceStr := make([]string, 0)
+	emptySliceInt := make([]int, 0)
+
+	// tests holds the tests we want to do and the result expected
+	var tests = []struct {
+		param     []string
+		wantSlInt []int
+		wantSlStr []string
+		err       error
+	}{
+		{s1, []int{0, 1}, emptySliceStr, errors.New("[FAIL]:: Failed to return the slice of ints")},
+		{s2, []int{0, 1, 2, 5, 6, 7}, emptySliceStr, errors.New("[FAIL]:: Failed to process 2 ranges of ints")},
+		{s3, emptySliceInt, emptySliceStr, errors.New("[FAIL]:: Failed to prcess empty args")},
+	}
+
+	// running tests
+	for _, tst := range tests {
+		gotSlInt, gotSlStr := processArgsRm(tst.param)
+		if SameSlicesInt(gotSlInt, tst.wantSlInt) || SameSlices(gotSlStr, tst.wantSlStr) {
+			t.Log(tst.err.Error())
+			t.Fail()
+		}
+	}
+}

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -20,6 +20,16 @@ func TestRmInSlice(t *testing.T) {
 	// empty
 	emptySlInt := make([]int, 0)
 	emptySlStr := make([]string, 0)
+	// many ints
+	sl3 := []int{0, 2}
+	// this
+	this, errDir := os.Getwd()
+	if errDir != nil {
+		t.Log(errDir.Error())
+	}
+	slThis := []string{this, "/tmp"}
+	// all (*)
+	slAll := []string{"*"}
 
 	var tests = []struct {
 		i     []int
@@ -32,6 +42,15 @@ func TestRmInSlice(t *testing.T) {
 		{emptySlInt, sl2, sl2, emptySlStr, errors.New("[FAIL]:: Can't return the nil slice, sad - str")},
 		{[]int{0}, emptySlStr, sl1, sl11, errors.New("[FAIL]:: Didn't remove shit - int")},
 		{[]int{0}, emptySlStr, sl2, emptySlStr, errors.New("[FAIL]:: Can't return the nil slice, sad - int")},
+		{[]int{0, 1}, emptySlStr, sl1, []string{"path3/sub3/subsub3"}, errors.New("[FAIL]:: This trash sh*t can't remove with multiple indexes")},
+		// many strings
+		{emptySlInt, sl11, sl1, []string{"path1/sub1/subsub1"}, errors.New("[FAIL]:: Failed to remove two paths at once. Noob")},
+		// many ints
+		{sl3, emptySlStr, sl1, []string{"path2/sub2/subsub2"}, errors.New("[FAIL]:: Failed to remove multiple ints at once")},
+		// this
+		{emptySlInt, []string{"this"}, slThis, []string{"/tmp"}, errors.New("[FAIL]:: Could not remove 'this': " + this)},
+		// all (*)
+		{emptySlInt, slAll, sl1, emptySlStr, errors.New("[FAIL]:: Failed to use the all-wildcard")},
 	}
 
 	// running tests
@@ -161,8 +180,8 @@ func TestWriteTempestcf(t *testing.T) {
 // It verifies that it returns the right slices
 func TestProcessArgsRm(t *testing.T) {
 	// parameter variables
-	// empty arg
-	s3 := []string{""}
+	// this arg
+	s3 := []string{"this"}
 	// index ranges
 	s1 := []string{"0-1"}
 	s2 := []string{"0-2", "5-7"}
@@ -178,7 +197,7 @@ func TestProcessArgsRm(t *testing.T) {
 	s9 := []string{"/tmp", "7", "2-5"}
 	s10 := []string{"2-5", "/tmp", "7"}
 	s11 := []string{"1-2", "3-4", "/temp", "5", "/tmp/user/aur", "6"}
-	s14 := []string{"0", "", "3-3", "/tmp"}
+	s14 := []string{"0", "this", "3-3", "/tmp"}
 	// Overlaping arguments
 	s13 := []string{"0-2", "1-3", "/tmp", "10", "/tmp"}
 

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 )
@@ -109,15 +110,22 @@ func TestRestoreTempestcf(t *testing.T) {
 // It is supposed to override the .tempestcf targets with a new slice of targets.
 func TestWriteTempestcf(t *testing.T) {
 
+	this, errDir := os.Getwd()
+	if errDir != nil {
+		log.Fatal(errDir)
+	}
+
 	sl1 := []string{
 		conf.Gobin,
 		conf.Gopath,
+		this,
 	}
 
 	// Presets for testing
 	tempestcfbup := setTestTempestcf(t, sl1)
 
 	newSl := rmInSlice(0, "", sl1)
+	newSl = rmInSlice(-1, "this", sl1)
 
 	// Try to use writeTempestcf
 	if err := writeTempestcf(newSl); err != nil {

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -229,3 +229,46 @@ func TestProcessArgsRm(t *testing.T) {
 		}
 	}
 }
+
+// TestSimpleDelAllString is the test for the func simpleDelAllString which is supposed
+// to delete from the system all paths provided in args
+func TestSimpleDelAllString(t *testing.T) {
+	// create a test directories
+	dir1 := conf.Gopath + string(os.PathSeparator) + "dir1"
+	dir2 := conf.Gopath + string(os.PathSeparator) + "dir2"
+	dir3 := conf.Gopath + string(os.PathSeparator) + "dir3"
+
+	dirs := []string{dir1, dir2, dir3}
+
+	for _, d := range dirs {
+		if err := os.Mkdir(d, 0777); err != nil {
+			t.Log("[ERROR]:: Failed to create test directeory:", d)
+			t.Fail()
+		}
+	}
+
+	// apply func on them in order to delete it
+	if err := simpleDelAllString(dirs...); err != nil {
+		t.Log("[FAIL]:: Failed to remove those directories")
+		t.Fail()
+	}
+
+	stillExisting := make([]string, 0)
+
+	// check if they got deleted for real
+	for _, d := range dirs {
+		if isDir, err := IsDirectory(d); isDir || err == nil {
+			stillExisting = append(stillExisting, d)
+			t.Log("[FAIL]:: Think it deletes but it doesn't, this is so mean, imma cry now. Bye!")
+			t.Fail()
+		}
+	}
+
+	// clean up the mess if one of the test dirs still exist
+	for _, se := range stillExisting {
+		if err := os.RemoveAll(se); err != nil {
+			t.Log("[ERROR]:: F*ck can't do sh*t.")
+			t.Fail()
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,12 @@ var greenB func(...interface{}) string
 // magB is a func used to print in bold magenta
 var magB func(...interface{}) string
 
+// Target is represented by an index and a path
+type Target struct {
+	Index int
+	Path  string
+}
+
 // RootCmd represents the base command when called without any subcommands
 //TODO Make full description with full help on how to use the CLI
 var RootCmd = &cobra.Command{
@@ -277,4 +283,34 @@ func IsDirectory(path string) (bool, error) {
 		return false, err
 	}
 	return fileInfo.IsDir(), nil
+}
+
+// IsIntInSlice returns true if the int is in the slice
+func IsIntInSlice(index int, sl []int) bool {
+	if len(sl) <= 0 || sl == nil {
+		return false
+	}
+
+	for _, val := range sl {
+		if val == index {
+			return true
+		}
+	}
+	return false
+}
+
+// IsStringInSlice returns true if the string is in the slice.
+// This one is more simple and faster than checkRedondance(slice, sliceArgs[]string) bool
+func IsStringInSlice(str string, sl []string) bool {
+	if len(sl) <= 0 || sl == nil {
+		return false
+	}
+
+	for _, val := range sl {
+		if val == str {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,11 +153,6 @@ func Execute() {
 
 func init() {
 	// Initialize the environment variables
-	if err := envconfig.Init(&conf); err != nil {
-		log.Fatal(err)
-	}
-
-	cobra.OnInitialize(initConfig)
 
 	home, err := homedir.Dir()
 	if err != nil {
@@ -165,6 +160,12 @@ func init() {
 		os.Exit(1)
 	}
 	conf.Home = home
+
+	cobra.OnInitialize(initConfig)
+
+	if err := envconfig.Init(&conf); err != nil {
+		// log.Println(err)
+	}
 
 	pathProg = conf.Gopath + string(os.PathSeparator) + "src" + string(os.PathSeparator) + "github.com" + string(os.PathSeparator) + "ChacaS0" + string(os.PathSeparator)
 	pathTempest = pathProg + "tempest" + string(os.PathSeparator)

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -6,7 +6,7 @@ import (
 
 // TestCallPurge is the test for callPurge(targets []string) error {}
 // It is not a really sexy test, only checks if there are no errors when
-// runing the func
+// running the func
 func TestCallPurge(t *testing.T) {
 	// setting the place
 	slTest := make([]string, 0)
@@ -14,14 +14,14 @@ func TestCallPurge(t *testing.T) {
 	// call it with test mode on
 	tTest = true
 	if err := callPurge(slTest); err != nil {
-		t.Log("[FAIL]:TESTMODE: An error occured when trying to use ``callPurge(", slTest, ")\n\t->", err)
+		t.Log("[FAIL]:TESTMODE: An error occurred when trying to use ``callPurge(", slTest, ")\n\t->", err)
 		t.Fail()
 	}
 
 	// call it without test mode on
 	tTest = false
 	if err := callPurge(slTest); err != nil {
-		t.Log("[FAIL]:REGMODE: An error occured when trying to use ``callPurge(", slTest, ")\n\t->", err)
+		t.Log("[FAIL]:REGMODE: An error occurred when trying to use ``callPurge(", slTest, ")\n\t->", err)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
### Changes include:
- [x] Being able to use range for removal using indexes or paths
- [x] Being able to use multiple values at once when calling ``tempest rm``
- [x] Update for the documentation
- [x] Update for the tests
- [x] Update for rm tutorial (gh-pages)
- [x] New flag: ``--origin``, which also removes the original files, not just in the **TEMPest** list  
  
  
--------
> Fixes #21