### PR TITLE
Implementation of ``tempest list --fix`` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ or
 export GOBIN=/usr/bin
 ```
 
+> You can also skip this step and then just add a symlink from ``$GOBIN/tempest`` to ``/usr/bin/tempest`` after the installation of **TEMPest**
+
+
 Then
 ```bash
 go get -v -u github.com/ChacaS0/tempest
@@ -55,6 +58,7 @@ Add this line to ``/etc/environment``:
 GOBIN=<PATH_OF_YOUR_CHOICE>
 PATH=$PATH:$GOBIN
 ```
+
 
 Then
 ```bash

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -84,7 +84,7 @@ func init() {
 	// addCmd.Flags().StringVarP(&this, "this", "t", "nothing", "Points to current directory")
 }
 
-// func addLine(argFlags []string, args []string) error {
+// addLine add each string as target into TEMPest (~/.tempestcf)
 func addLine(args []string) error {
 	// Check if the path already exists first in tempestcf
 	// ctnt, errRead := ioutil.ReadFile(conf.Home + "/.tempestcf")

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -102,3 +102,15 @@ func TestPrintList(t *testing.T) {
 	// Fallback
 	fbTestTempestcf(t, tempestcfbup)
 }
+
+// TestGetState is the func that checks if getState give the right state.
+// Meaning { True : "good", False: "Not good"}
+func TestGetState(t *testing.T) {
+	// TODO: to input non existing paths to TEMPest, we can write directly to the file?
+	//
+}
+
+// TestFixTargets is the func that checks if it deletes all the broken targets
+func TestFixTargets(t *testing.T) {
+	// TODO:
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -103,14 +103,142 @@ func TestPrintList(t *testing.T) {
 	fbTestTempestcf(t, tempestcfbup)
 }
 
-// TestGetState is the func that checks if getState give the right state.
-// Meaning { True : "good", False: "Not good"}
-func TestGetState(t *testing.T) {
-	// TODO: to input non existing paths to TEMPest, we can write directly to the file?
-	//
-}
-
 // TestFixTargets is the func that checks if it deletes all the broken targets
 func TestFixTargets(t *testing.T) {
-	// TODO:
+	// Create a temp dir for the test
+	testPath := conf.Gopath + string(os.PathSeparator) + "test"
+	if err := os.Mkdir(testPath, 0777); err != nil {
+		t.Log("[ERROR]:: Could not create the test directory: ", testPath, "\n\t->", err)
+		t.Fail()
+	}
+
+	// Add targets to TEMPest
+	tempestcfbup := setTestTempestcf(t, []string{conf.Gobin, conf.Gopath, testPath})
+
+	// Get paths added
+	allPaths, errGP := getPaths()
+	if errGP != nil {
+		t.Log("[ERROR]:: Could not retrieve the paths added:\n\t", errGP)
+	}
+
+	// We can test here if nothing changes when it's all good
+	if err := fixTargets(); err != nil {
+		t.Log("[ERROR]:: Sorry it spotted broken targets and removed them when there was supposed to be none.\n\t->ERROR:: ", err)
+		t.Fail()
+	}
+	// Real check
+	pathsAfter, errGPAfter := getPaths()
+	if errGP != nil {
+		t.Log("[ERROR]:: Could not retrieve the paths added:\n\t", errGPAfter)
+		t.Fail()
+	}
+	if !SameSlices(allPaths, pathsAfter) {
+		t.Log("[FAIL]:: Removed stuff it should have to.\n\tGOT: ", pathsAfter, "\n\tWANT: ", allPaths)
+		t.Fail()
+	}
+
+	// Typical broken path is on who got deleted on the system but not in TEMPest
+	// So that's we are going to simulate
+	// Deletion of testPath
+	if err := os.Remove(testPath); err != nil {
+		t.Log("[ERROR]:: Fuck could not delete the f*cking testPath, can't test like this!\n\t", err)
+		t.Fail()
+	}
+
+	// Now we can test the func to see if it does report a broken Target (testPath)
+	if err := fixTargets(); err != nil {
+		t.Log("[ERROR]:: Sorry the fix was wrong (did not take care of the broken target)!\n\t->ERROR: ", err)
+		t.Fail()
+	}
+	// Real check
+	pathsAfter, errGPAfter = getPaths()
+	if errGP != nil {
+		t.Log("[ERROR]:: Could not retrieve the paths added:\n\t", errGPAfter)
+		t.Fail()
+	}
+	// preparing results
+	cpt := 0 // we want it to get to 3
+	for _, pa := range pathsAfter {
+		switch pa {
+		case conf.Gobin:
+			cpt++
+		case conf.Gopath:
+			cpt++
+		}
+	}
+	if !IsStringInSlice(testPath, pathsAfter) {
+		cpt++
+	}
+	// Handle results
+	if cpt != 3 {
+		t.Log("[FAIL]:: Damn, something went terribly wrong!!\n\tGOT: ", pathsAfter, "\n\tWANT: ", []string{conf.Gobin, conf.Gopath})
+		t.Fail()
+	}
+
+	// Fall back to repvious .tempestcf
+	fbTestTempestcf(t, tempestcfbup)
+
+}
+
+// TestGetState is the func that checks if getState give the right state.
+// Meaning => { True : "good", False: "Not good"}
+func TestGetState(t *testing.T) {
+	// Create a temp dir for the test
+	testPath := conf.Gopath + string(os.PathSeparator) + "test"
+	if err := os.Mkdir(testPath, 0777); err != nil {
+		t.Log("[ERROR]:: Could not create the test directory: ", testPath, "\n\t->", err)
+		t.Fail()
+	}
+
+	// Add targets to TEMPest
+	tempestcfbup := setTestTempestcf(t, []string{conf.Gobin, conf.Gopath, testPath})
+
+	// Get paths added
+	allPaths, errGP := getPaths()
+	if errGP != nil {
+		t.Log("[ERROR]:: Could not retrieve the paths added:\n\t", errGP)
+	}
+	// String paths to targets
+	allTargets := PathsToTargets(allPaths)
+
+	// retrieve the individual Targets
+	var testTarget Target
+	var testGopath Target
+	var testGobin Target
+	for _, tgt := range allTargets {
+		switch tgt.Path {
+		case testPath:
+			testTarget = tgt
+		case conf.Gobin:
+			testGobin = tgt
+		case conf.Gopath:
+			testGopath = tgt
+		}
+	}
+
+	// We can test here if all targets are "good"
+	stateTgts := getState(allTargets)
+	if !stateTgts[testTarget] || !stateTgts[testGobin] || !stateTgts[testGopath] {
+		t.Log("[FAIL]:: Sorry it spotted broken targets when there was supposed to be none.\n\t->GOT: ", stateTgts)
+		t.Fail()
+	}
+
+	// Typical broken path is on who got deleted on the system but not in TEMPest
+	// So that's we are going to simulate
+	// Deletion of testPath
+	if err := os.Remove(testPath); err != nil {
+		t.Log("[ERROR]:: Fuck could not delete the f*cking testPath, can't test like this!\n\t", err)
+		t.Fail()
+	}
+
+	// Now we can test the func to see if it does report a broken Target (testPath)
+	stateTgts = getState(allTargets)
+	if stateTgts[testTarget] || !stateTgts[testGobin] || !stateTgts[testGopath] {
+		t.Log("[FAIL]:: Sorry the states were wrong (did not spot the broken target)!\n\t->GOT: ", stateTgts)
+		t.Fail()
+	}
+
+	// Fall back to repvious .tempestcf
+	fbTestTempestcf(t, tempestcfbup)
+
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,6 @@
-// Copyright © 2018 Sebastien Bastide
+// Package cmd contains all the commands for TEMPest.
 //
+// Copyright © 2018 Sebastien Bastide
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -17,7 +18,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 package cmd
 
 import (
@@ -91,6 +91,7 @@ var greenB func(...interface{}) string
 var magB func(...interface{}) string
 
 // Target is represented by an index and a path
+// Later this will hold the type(directory or file)
 type Target struct {
 	Index int
 	Path  string
@@ -314,4 +315,15 @@ func IsStringInSlice(str string, sl []string) bool {
 	}
 
 	return false
+}
+
+// PathsToTargets is a converter, takes paths (strings) and convert them into targets (Target)
+func PathsToTargets(paths []string) []Target {
+	sliceTgt := make([]Target, 0)
+
+	for i, p := range paths {
+		sliceTgt = append(sliceTgt, Target{i, p})
+	}
+
+	return sliceTgt
 }


### PR DESCRIPTION
 This flag fixes broken paths for the **TEMPest** ``Target``s.

*Also, improves the use of ``Target`` instead of ``string``s for ``paths`` and ``int``s for ``indexes``*

------------------
Fixes #20 